### PR TITLE
Add windows build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-  swapfile_size: 0GiB
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,86 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: win
+  pool:
+    vmImage: windows-2022
+  strategy:
+    matrix:
+      win_64_:
+        CONFIG: win_64_
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables:
+    CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
+
+  steps:
+    - task: PythonScript@0
+      displayName: 'Download Miniforge'
+      inputs:
+        scriptSource: inline
+        script: |
+          import urllib.request
+          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
+          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
+          urllib.request.urlretrieve(url, path)
+
+    - script: |
+        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
+      displayName: Install Miniforge
+
+    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
+      displayName: Add conda to PATH
+
+    - script: |
+        call activate base
+        mamba.exe install "python=3.10" conda-build conda pip boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
+      displayName: Install conda-build
+
+    - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
+
+    # Configure the VM
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
+
+    # Configure the VM.
+    - script: |
+        set "CI=azure"
+        call activate base
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+
+    - script: |
+        call activate base
+        if EXIST LICENSE.txt (
+          copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+      displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
+    - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
+      displayName: Validate Recipe Outputs
+
+    - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
+        call activate base
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+      displayName: Upload package
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+        FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+        STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')), not(eq(variables['Build.Reason'], 'PullRequest')))

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,0 +1,8 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+target_platform:
+- win-64

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/level-zero-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18960&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/level-zero-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,3 +4,4 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,10 +3,10 @@ mkdir build
 mkdir install
 
 cmake -G Ninja -DCMAKE_INSTALL_PREFIX="install" ^
-    -S ${SRC_DIR}\level-zero ^
+    -S "%SRC_DIR%\level-zero" ^
     -B build ^
     -Wno-dev
 
-cmake --build ${SRC_DIR}/build --config Release
-cmake --build ${SRC_DIR}/build --config Release --target install
+cmake --build build --config Release
+cmake --build build --config Release --target install
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,12 @@
+
+mkdir build
+mkdir install
+
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX="install" ^
+    -S ${SRC_DIR}\level-zero ^
+    -B build ^
+    -Wno-dev
+
+cmake --build ${SRC_DIR}/build --config Release
+cmake --build ${SRC_DIR}/build --config Release --target install
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,9 +3,10 @@
 mkdir build
 mkdir install
 
-cmake -DCMAKE_INSTALL_PREFIX="${SRC_DIR}/install" \
+cmake -GNinja -DCMAKE_INSTALL_PREFIX="./install" \
     -S ${SRC_DIR}/level-zero \
-    -B ${SRC_DIR}/build \
+    -B ./build \
     -Wno-dev
-cmake --build ${SRC_DIR}/build --config Release -- -j${CPU_COUNT}
-cmake --build ${SRC_DIR}/build --config Release --target install
+
+cmake --build ./build --config Release
+cmake --build ./build --config Release --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,20 @@ source:
     folder: level-zero
 
 build:
-  number: 0
-  skip: true  # [not (x86 and (linux))]
+  number: 1
+  skip: true  # [not (x86 and (linux or win))]
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - cmake
-    - make
+    - ninja
 
 outputs:
   - name: level-zero
     version: {{ version }}
-    script: move-level-zero.sh
+    script: move-level-zero.sh  # [linux]
+    script: move-level-zero.bat  # [win]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -36,16 +37,18 @@ outputs:
         oneAPI Level Zero
     test:
       commands:
-        - ls -A1 ${PREFIX}/lib   # [linux]
-        - test -f ${PREFIX}/lib/libze_loader.so.1   # [linux]
-        - test -f ${PREFIX}/lib/libze_loader.so.{{ test_version }}   # [linux]
-        - test -f ${PREFIX}/lib/libze_tracing_layer.so.1   # [linux]
-        - test -f ${PREFIX}/lib/libze_tracing_layer.so.{{ test_version }}   # [linux]
-        - test -f ${PREFIX}/lib/libze_validation_layer.so.1   # [linux]
-        - test -f ${PREFIX}/lib/libze_validation_layer.so.{{ test_version }}   # [linux]
+        - ls -A1 ${PREFIX}/lib  # [linux]
+        - dir "%LIBRARY_BIN%"  # [win]
+        - test -f ${PREFIX}/lib/libze_loader.so.1  # [linux]
+        - test -f ${PREFIX}/lib/libze_loader.so.{{ test_version }}  # [linux]
+        - test -f ${PREFIX}/lib/libze_tracing_layer.so.1  # [linux]
+        - test -f ${PREFIX}/lib/libze_tracing_layer.so.{{ test_version }}  # [linux]
+        - test -f ${PREFIX}/lib/libze_validation_layer.so.1  # [linux]
+        - test -f ${PREFIX}/lib/libze_validation_layer.so.{{ test_version }}  # [linux]
   - name: level-zero-devel
     version: {{ version }}
-    script: move-level-zero-devel.sh
+    script: move-level-zero-devel.sh  # [linux]
+    script: move-level-zero-devel.bat  # [win]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -59,14 +62,16 @@ outputs:
         oneAPI Level Zero development libs
     test:
       commands:
-        - test -f ${PREFIX}/lib/libze_loader.so   # [linux]
-        - test -f ${PREFIX}/lib/libze_tracing_layer.so   # [linux]
-        - test -f ${PREFIX}/lib/libze_validation_layer.so   # [linux]
-        - test -d ${PREFIX}/include/level_zero   # [linux]
-        - test -d ${PREFIX}/include/level_zero/loader   # [linux]
-        - test -d ${PREFIX}/include/level_zero/layers   # [linux]
-        - test -f ${PREFIX}/lib/pkgconfig/libze_loader.pc   # [linux]
-        - test -f ${PREFIX}/lib/pkgconfig/level-zero.pc   # [linux]
+        - dir "%LIBRARY_LIB%"  # [win]
+        - dir "%LIBRARY_INC%"  # [win]
+        - test -f ${PREFIX}/lib/libze_loader.so  # [linux]
+        - test -f ${PREFIX}/lib/libze_tracing_layer.so  # [linux]
+        - test -f ${PREFIX}/lib/libze_validation_layer.so  # [linux]
+        - test -d ${PREFIX}/include/level_zero  # [linux]
+        - test -d ${PREFIX}/include/level_zero/loader  # [linux]
+        - test -d ${PREFIX}/include/level_zero/layers  # [linux]
+        - test -f ${PREFIX}/lib/pkgconfig/libze_loader.pc  # [linux]
+        - test -f ${PREFIX}/lib/pkgconfig/level-zero.pc  # [linux]
 
 about:
   home: https://github.com/oneapi-src/level-zero

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ outputs:
     test:
       commands:
         - ls -A1 ${PREFIX}/lib  # [linux]
-        - dir "%LIBRARY_BIN%"  # [win]
+        - dir /S "%LIBRARY_BIN%"  # [win]
         - test -f ${PREFIX}/lib/libze_loader.so.1  # [linux]
         - test -f ${PREFIX}/lib/libze_loader.so.{{ test_version }}  # [linux]
         - test -f ${PREFIX}/lib/libze_tracing_layer.so.1  # [linux]
@@ -63,7 +63,7 @@ outputs:
     test:
       commands:
         - dir "%LIBRARY_LIB%"  # [win]
-        - dir "%LIBRARY_INC%"  # [win]
+        - dir /S "%LIBRARY_INC%"  # [win]
         - test -f ${PREFIX}/lib/libze_loader.so  # [linux]
         - test -f ${PREFIX}/lib/libze_tracing_layer.so  # [linux]
         - test -f ${PREFIX}/lib/libze_validation_layer.so  # [linux]

--- a/recipe/move-level-zero-devel.bat
+++ b/recipe/move-level-zero-devel.bat
@@ -1,14 +1,19 @@
 @echo on
 
-robocopy /E ".\install\include\" "%LIBRARY_INC%"
+robocopy ".\install\include" "%LIBRARY_INC%" /S /E
 if %ERRORLEVEL% GEQ 8 exit 1
 
 copy /Y ".\install\lib\ze_loader.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% 1 exit 1
+if errorlevel 1 exit 1
 
-copy /Y ".\install\lib\ze_tracing_layer.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% 1 exit 1
+REM LAYER DLL files are not correctly installed by Level-Zero
+REM CMakeLists.txt. They are skipped on Windows for now, and hence 
+REM LIB files are not copied as well. See
+REM    https://github.com/oneapi-src/level-zero/pull/122
 
-copy /Y ".\install\lib\ze_validation_layer.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% 1 exit 1
+REM copy /Y ".\install\lib\ze_tracing_layer.lib" "%LIBRARY_LIB%"
+REM if %ERRORLEVEL% 1 exit 1
+
+REM copy /Y ".\install\lib\ze_validation_layer.lib" "%LIBRARY_LIB%"
+REM if %ERRORLEVEL% 1 exit 1
 

--- a/recipe/move-level-zero-devel.bat
+++ b/recipe/move-level-zero-devel.bat
@@ -1,0 +1,14 @@
+@echo on
+
+robocopy /E ".\install\include\*" "%LIBRARY_INC%"
+if %ERRORLEVEL% GEQ 8 exit 1
+
+robocopy /E ".\install\lib\ze_loader.lib" "%LIBRARY_LIB%"
+if %ERRORLEVEL% GEQ 8 exit 1
+
+robocopy /E ".\install\lib\ze_tracing_layer.lib" "%LIBRARY_LIB%"
+if %ERRORLEVEL% GEQ 8 exit 1
+
+robocopy /E ".\install\lib\ze_validation_layer.lib" "%LIBRARY_LIB%"
+if %ERRORLEVEL% GEQ 8 exit 1
+

--- a/recipe/move-level-zero-devel.bat
+++ b/recipe/move-level-zero-devel.bat
@@ -4,11 +4,11 @@ robocopy /E ".\install\include\" "%LIBRARY_INC%"
 if %ERRORLEVEL% GEQ 8 exit 1
 
 copy /Y ".\install\lib\ze_loader.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% exit 1
+if %ERRORLEVEL% 1 exit 1
 
 copy /Y ".\install\lib\ze_tracing_layer.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% exit 1
+if %ERRORLEVEL% 1 exit 1
 
 copy /Y ".\install\lib\ze_validation_layer.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% exit 1
+if %ERRORLEVEL% 1 exit 1
 

--- a/recipe/move-level-zero-devel.bat
+++ b/recipe/move-level-zero-devel.bat
@@ -1,14 +1,14 @@
 @echo on
 
-robocopy /E ".\install\include\*" "%LIBRARY_INC%"
+robocopy /E ".\install\include\" "%LIBRARY_INC%"
 if %ERRORLEVEL% GEQ 8 exit 1
 
-robocopy /E ".\install\lib\ze_loader.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% GEQ 8 exit 1
+copy /Y ".\install\lib\ze_loader.lib" "%LIBRARY_LIB%"
+if %ERRORLEVEL% exit 1
 
-robocopy /E ".\install\lib\ze_tracing_layer.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% GEQ 8 exit 1
+copy /Y ".\install\lib\ze_tracing_layer.lib" "%LIBRARY_LIB%"
+if %ERRORLEVEL% exit 1
 
-robocopy /E ".\install\lib\ze_validation_layer.lib" "%LIBRARY_LIB%"
-if %ERRORLEVEL% GEQ 8 exit 1
+copy /Y ".\install\lib\ze_validation_layer.lib" "%LIBRARY_LIB%"
+if %ERRORLEVEL% exit 1
 

--- a/recipe/move-level-zero-devel.sh
+++ b/recipe/move-level-zero-devel.sh
@@ -2,12 +2,12 @@
 
 set -ex
 
-pushd ${SRC_DIR}
 mkdir -p ${PREFIX}/lib/pkgconfig
 mkdir -p ${PREFIX}/include
-cp -a install/include/* ${PREFIX}/include/
-cp -a install/lib*/pkgconfig/* ${PREFIX}/lib/pkgconfig
-cp -a install/lib*/libze_loader.so ${PREFIX}/lib/
-cp -a install/lib*/libze_tracing_layer.so ${PREFIX}/lib/
-cp -a install/lib*/libze_validation_layer.so ${PREFIX}/lib/
-popd
+
+cp -a ./install/include/* ${PREFIX}/include/
+cp -a ./install/lib*/pkgconfig/* ${PREFIX}/lib/pkgconfig
+cp -a ./install/lib*/libze_loader.so ${PREFIX}/lib/
+cp -a ./install/lib*/libze_tracing_layer.so ${PREFIX}/lib/
+cp -a ./install/lib*/libze_validation_layer.so ${PREFIX}/lib/
+

--- a/recipe/move-level-zero.bat
+++ b/recipe/move-level-zero.bat
@@ -1,13 +1,15 @@
 @echo on
 
-dir /S install
-
 copy /Y ".\install\bin\ze_loader.dll" "%LIBRARY_BIN%"
 if errorlevel 1 exit 1
 
-copy /Y ".\install\bin\ze_tracing_layer.dll" "%LIBRARY_BIN%"
-if errorlevel 1 exit 1
+REM LAYER DLL files are not correctly installed by Level-Zero
+REM CMakeLists.txt. They are skipped on Windows for now. See
+REM    https://github.com/oneapi-src/level-zero/pull/122
 
-copy /Y ".\install\bin\ze_validation_layer.dll" "%LIBRARY_BIN%"
-if errorlevel 1 exit 1
+REM copy /Y ".\install\bin\ze_tracing_layer.dll" "%LIBRARY_BIN%"
+REM if errorlevel 1 exit 1
+
+REM copy /Y ".\install\bin\ze_validation_layer.dll" "%LIBRARY_BIN%"
+REM if errorlevel 1 exit 1
 

--- a/recipe/move-level-zero.bat
+++ b/recipe/move-level-zero.bat
@@ -2,12 +2,12 @@
 
 if not exist "%PREFIX%/lib" mkdir "%PREFIX%/lib"
 
-robocopy /E ".\install\bin\ze_loader.dll" "%LIBRARY_BIN%"
-if %ERRORLEVEL% GEQ 8 exit 1
+copy /Y ".\install\bin\ze_loader.dll" "%LIBRARY_BIN%"
+if %ERRORLEVEL% exit 1
 
-robocopy /E ".\install\bin\ze_tracing_layer.dll" "%LIBRARY_BIN%"
-if %ERRORLEVEL% GEQ 8 exit 1
+copy /Y ".\install\bin\ze_tracing_layer.dll" "%LIBRARY_BIN%"
+if %ERRORLEVEL% exit 1
 
 robocopy /E ".\install\bin\ze_validation_layer.dll" "%LIBRARY_BIN%"
-if %ERRORLEVEL% GEQ 8 exit 1
+if %ERRORLEVEL% exit 1
 

--- a/recipe/move-level-zero.bat
+++ b/recipe/move-level-zero.bat
@@ -1,0 +1,13 @@
+@echo on
+
+if not exist "%PREFIX%/lib" mkdir "%PREFIX%/lib"
+
+robocopy /E ".\install\bin\ze_loader.dll" "%LIBRARY_BIN%"
+if %ERRORLEVEL% GEQ 8 exit 1
+
+robocopy /E ".\install\bin\ze_tracing_layer.dll" "%LIBRARY_BIN%"
+if %ERRORLEVEL% GEQ 8 exit 1
+
+robocopy /E ".\install\bin\ze_validation_layer.dll" "%LIBRARY_BIN%"
+if %ERRORLEVEL% GEQ 8 exit 1
+

--- a/recipe/move-level-zero.bat
+++ b/recipe/move-level-zero.bat
@@ -1,13 +1,13 @@
 @echo on
 
-if not exist "%PREFIX%/lib" mkdir "%PREFIX%/lib"
+dir /S install
 
 copy /Y ".\install\bin\ze_loader.dll" "%LIBRARY_BIN%"
-if %ERRORLEVEL% exit 1
+if errorlevel 1 exit 1
 
 copy /Y ".\install\bin\ze_tracing_layer.dll" "%LIBRARY_BIN%"
-if %ERRORLEVEL% exit 1
+if errorlevel 1 exit 1
 
-robocopy /E ".\install\bin\ze_validation_layer.dll" "%LIBRARY_BIN%"
-if %ERRORLEVEL% exit 1
+copy /Y ".\install\bin\ze_validation_layer.dll" "%LIBRARY_BIN%"
+if errorlevel 1 exit 1
 

--- a/recipe/move-level-zero.sh
+++ b/recipe/move-level-zero.sh
@@ -2,9 +2,9 @@
 
 set -ex
 
-pushd ${SRC_DIR}
 mkdir -p ${PREFIX}/lib
-cp -a install/lib*/libze_loader.so.1* ${PREFIX}/lib/
-cp -a install/lib*/libze_tracing_layer.so.1* ${PREFIX}/lib/
-cp -a install/lib*/libze_validation_layer.so.1* ${PREFIX}/lib/
-popd
+
+cp -a ./install/lib*/libze_loader.so.1* ${PREFIX}/lib/
+cp -a ./install/lib*/libze_tracing_layer.so.1* ${PREFIX}/lib/
+cp -a ./install/lib*/libze_validation_layer.so.1* ${PREFIX}/lib/
+


### PR DESCRIPTION
Added Windows build, to make "level-zero-devel" package available on Windows. 

Level Zero loader is normally provided by system-wide installation of graphics drivers, but it does not contain ".lib" files and include headers needed to build applications using Level-Zero.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

