### PR TITLE
Feature/add run exports

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kurapov-peter @oleksandr-pavlyk
+* @ZzEeKkAa @kurapov-peter @oleksandr-pavlyk

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@ZzEeKkAa](https://github.com/ZzEeKkAa/)
 * [@kurapov-peter](https://github.com/kurapov-peter/)
 * [@oleksandr-pavlyk](https://github.com/oleksandr-pavlyk/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,3 +98,4 @@ extra:
   recipe-maintainers:
     - oleksandr-pavlyk
     - kurapov-peter
+    - ZzEeKkAa

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     folder: level-zero
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not (x86 and (linux or win))]
 
 requirements:
@@ -55,6 +55,9 @@ outputs:
     version: {{ version }}
     script: move-level-zero-devel.sh  # [linux]
     script: move-level-zero-devel.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_subpackage('level-zero', max_pin="x") }}
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
Add run_export so if client uses `level-zero-devel` it pins compatible abi dependency.
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
